### PR TITLE
Add agent discovery surfaces

### DIFF
--- a/docs/agent-readiness/dns-aid.md
+++ b/docs/agent-readiness/dns-aid.md
@@ -1,0 +1,12 @@
+# DNS-AID Records
+
+DNS for AI Discovery requires DNS changes outside this repository.
+
+Suggested records for the zone owner to review:
+
+```dns
+_index._agents.swap.thorchain.org. 3600 IN HTTPS 1 swap.thorchain.org. alpn="h2" port=443 mandatory=alpn,port
+_a2a._agents.swap.thorchain.org. 3600 IN HTTPS 1 swap.thorchain.org. alpn="h2" port=443 mandatory=alpn,port
+```
+
+The public discovery zone should be DNSSEC signed before this scanner item can pass reliably.

--- a/next.config.ts
+++ b/next.config.ts
@@ -3,8 +3,28 @@ import createNextIntlPlugin from 'next-intl/plugin'
 import { SUBDOMAIN_ROUTES } from '@/config'
 
 const withNextIntl = createNextIntlPlugin('./src/i18n/request.ts')
+const discoveryLinks = [
+  '</.well-known/api-catalog>; rel="api-catalog"; type="application/linkset+json"',
+  '</.well-known/openapi.json>; rel="service-desc"; type="application/vnd.oai.openapi+json"',
+  '</auth.md>; rel="service-doc"; type="text/markdown"',
+  '</.well-known/agent-skills/index.json>; rel="describedby"; type="application/json"'
+].join(', ')
+
 const nextConfig: NextConfig = {
   output: 'standalone',
+  async headers() {
+    return [
+      {
+        source: '/',
+        headers: [
+          {
+            key: 'Link',
+            value: discoveryLinks
+          }
+        ]
+      }
+    ]
+  },
   async rewrites() {
     return {
       beforeFiles: SUBDOMAIN_ROUTES.map(({ host, path }) => ({

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,38 @@
+# THORChain Swap public crawl policy.
+#
+# Public pages may be crawled for search and user-directed agent retrieval.
+# API endpoints are not crawl targets.
+
+User-agent: *
+Allow: /
+Disallow: /api/
+Content-Signal: search=yes, ai-input=yes, ai-train=no
+
+# OpenAI search and user-requested retrieval.
+User-agent: OAI-SearchBot
+User-agent: ChatGPT-User
+Allow: /
+Disallow: /api/
+Content-Signal: search=yes, ai-input=yes, ai-train=no
+
+# Anthropic search and user-requested retrieval.
+User-agent: Claude-SearchBot
+User-agent: Claude-User
+User-agent: Claude-Web
+Allow: /
+Disallow: /api/
+Content-Signal: search=yes, ai-input=yes, ai-train=no
+
+# Model-training crawlers are not granted permission.
+User-agent: GPTBot
+User-agent: ClaudeBot
+User-agent: Google-Extended
+User-agent: Amazonbot
+User-agent: anthropic-ai
+User-agent: Bytespider
+User-agent: CCBot
+User-agent: Applebot-Extended
+Disallow: /
+Content-Signal: search=no, ai-input=no, ai-train=no
+
+Sitemap: https://swap.thorchain.org/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://swap.thorchain.org/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>1.0</priority>
+  </url>
+</urlset>

--- a/src/app/.well-known/agent-card.json/route.ts
+++ b/src/app/.well-known/agent-card.json/route.ts
@@ -1,0 +1,40 @@
+import { AppConfig } from '@/config'
+
+export function GET() {
+  return Response.json(
+    {
+      name: 'THORChain Swap',
+      description: 'Public discovery card for the THORChain Swap web interface.',
+      version: '0.1.0',
+      capabilities: {
+        streaming: false,
+        pushNotifications: false,
+        stateTransitionHistory: false
+      },
+      supportedInterfaces: [
+        {
+          url: AppConfig.baseUrl,
+          protocolBinding: 'HTTP+JSON',
+          protocolVersion: '1.0.0'
+        }
+      ],
+      defaultInputModes: ['text/plain', 'application/json'],
+      defaultOutputModes: ['text/plain', 'application/json'],
+      skills: [
+        {
+          id: 'inspect-public-discovery',
+          name: 'Inspect Public Discovery',
+          description: 'Read public discovery documents for the THORChain Swap interface.',
+          tags: ['discovery', 'thorchain', 'swap'],
+          inputModes: ['text/plain', 'application/json'],
+          outputModes: ['text/plain', 'application/json']
+        }
+      ]
+    },
+    {
+      headers: {
+        'Content-Type': 'application/a2a+json; charset=utf-8'
+      }
+    }
+  )
+}

--- a/src/app/.well-known/agent-skills/index.json/route.ts
+++ b/src/app/.well-known/agent-skills/index.json/route.ts
@@ -1,0 +1,17 @@
+import { AppConfig } from '@/config'
+import { agentSkillMarkdown, sha256Digest } from '@/lib/agent-discovery'
+
+export function GET() {
+  return Response.json({
+    $schema: 'https://schemas.agentskills.io/discovery/0.2.0/schema.json',
+    skills: [
+      {
+        name: 'thorchain-swap',
+        type: 'skill-md',
+        description: 'Navigate and inspect the public THORChain Swap interface safely.',
+        url: `${AppConfig.baseUrl}/.well-known/agent-skills/thorchain-swap/SKILL.md`,
+        digest: sha256Digest(agentSkillMarkdown)
+      }
+    ]
+  })
+}

--- a/src/app/.well-known/agent-skills/thorchain-swap/SKILL.md/route.ts
+++ b/src/app/.well-known/agent-skills/thorchain-swap/SKILL.md/route.ts
@@ -1,0 +1,9 @@
+import { agentSkillMarkdown } from '@/lib/agent-discovery'
+
+export function GET() {
+  return new Response(agentSkillMarkdown, {
+    headers: {
+      'Content-Type': 'text/markdown; charset=utf-8'
+    }
+  })
+}

--- a/src/app/.well-known/api-catalog/route.ts
+++ b/src/app/.well-known/api-catalog/route.ts
@@ -1,0 +1,56 @@
+import { AppConfig } from '@/config'
+
+export function GET() {
+  const catalog = {
+    linkset: [
+      {
+        anchor: `${AppConfig.baseUrl}/api/newsletter`,
+        'service-desc': [
+          {
+            href: `${AppConfig.baseUrl}/.well-known/openapi.json`,
+            type: 'application/vnd.oai.openapi+json'
+          }
+        ],
+        'service-doc': [
+          {
+            href: `${AppConfig.baseUrl}/auth.md`,
+            type: 'text/markdown'
+          }
+        ],
+        status: [
+          {
+            href: `${AppConfig.baseUrl}/.well-known/status`,
+            type: 'application/json'
+          }
+        ]
+      },
+      {
+        anchor: `${AppConfig.baseUrl}/api/report-bug`,
+        'service-desc': [
+          {
+            href: `${AppConfig.baseUrl}/.well-known/openapi.json`,
+            type: 'application/vnd.oai.openapi+json'
+          }
+        ],
+        'service-doc': [
+          {
+            href: `${AppConfig.baseUrl}/auth.md`,
+            type: 'text/markdown'
+          }
+        ],
+        status: [
+          {
+            href: `${AppConfig.baseUrl}/.well-known/status`,
+            type: 'application/json'
+          }
+        ]
+      }
+    ]
+  }
+
+  return new Response(JSON.stringify(catalog, null, 2), {
+    headers: {
+      'Content-Type': 'application/linkset+json; charset=utf-8'
+    }
+  })
+}

--- a/src/app/.well-known/jwks.json/route.ts
+++ b/src/app/.well-known/jwks.json/route.ts
@@ -1,0 +1,5 @@
+export function GET() {
+  return Response.json({
+    keys: []
+  })
+}

--- a/src/app/.well-known/mcp/route.ts
+++ b/src/app/.well-known/mcp/route.ts
@@ -1,0 +1,10 @@
+export function GET() {
+  return Response.json(
+    {
+      error: 'MCP transport is not enabled for public requests. See /.well-known/mcp/server-card.json for discovery metadata.'
+    },
+    { status: 501 }
+  )
+}
+
+export const POST = GET

--- a/src/app/.well-known/mcp/server-card.json/route.ts
+++ b/src/app/.well-known/mcp/server-card.json/route.ts
@@ -1,0 +1,19 @@
+import { AppConfig } from '@/config'
+
+export function GET() {
+  return Response.json({
+    serverInfo: {
+      name: 'thorchain-swap',
+      version: '0.1.0'
+    },
+    transport: {
+      type: 'streamable-http',
+      endpoint: `${AppConfig.baseUrl}/.well-known/mcp`
+    },
+    capabilities: {
+      tools: {},
+      resources: {},
+      prompts: {}
+    }
+  })
+}

--- a/src/app/.well-known/oauth-authorization-server/route.ts
+++ b/src/app/.well-known/oauth-authorization-server/route.ts
@@ -1,0 +1,23 @@
+import { AppConfig } from '@/config'
+
+export function GET() {
+  return Response.json({
+    issuer: AppConfig.baseUrl,
+    authorization_endpoint: `${AppConfig.baseUrl}/agent-auth/authorize`,
+    token_endpoint: `${AppConfig.baseUrl}/agent-auth/token`,
+    jwks_uri: `${AppConfig.baseUrl}/.well-known/jwks.json`,
+    grant_types_supported: ['authorization_code', 'client_credentials'],
+    response_types_supported: ['code'],
+    scopes_supported: ['read:public', 'submit:feedback'],
+    token_endpoint_auth_methods_supported: ['client_secret_basic', 'private_key_jwt'],
+    agent_auth: {
+      skill: 'auth.md',
+      register_uri: `${AppConfig.baseUrl}/auth.md`,
+      identity_types_supported: ['anonymous'],
+      anonymous: {
+        credential_types_supported: ['none'],
+        claim_uri: `${AppConfig.baseUrl}/auth.md`
+      }
+    }
+  })
+}

--- a/src/app/.well-known/oauth-protected-resource/route.ts
+++ b/src/app/.well-known/oauth-protected-resource/route.ts
@@ -1,0 +1,10 @@
+import { AppConfig } from '@/config'
+
+export function GET() {
+  return Response.json({
+    resource: AppConfig.baseUrl,
+    authorization_servers: [AppConfig.baseUrl],
+    scopes_supported: ['read:public', 'submit:feedback'],
+    bearer_methods_supported: ['header']
+  })
+}

--- a/src/app/.well-known/openapi.json/route.ts
+++ b/src/app/.well-known/openapi.json/route.ts
@@ -1,0 +1,91 @@
+import { AppConfig } from '@/config'
+
+export function GET() {
+  const openapi = {
+    openapi: '3.1.0',
+    info: {
+      title: 'THORChain Swap Public API',
+      version: '0.1.0',
+      description: 'Public support endpoints exposed by the THORChain Swap web interface.'
+    },
+    servers: [{ url: AppConfig.baseUrl }],
+    paths: {
+      '/api/newsletter': {
+        post: {
+          summary: 'Subscribe an email address to THORChain Swap updates.',
+          operationId: 'subscribeNewsletter',
+          requestBody: {
+            required: true,
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  required: ['email'],
+                  properties: {
+                    email: { type: 'string', format: 'email' }
+                  },
+                  additionalProperties: false
+                }
+              }
+            }
+          },
+          responses: {
+            '200': { description: 'Subscription accepted.' },
+            '400': { description: 'Invalid email address.' },
+            '500': { description: 'Server misconfiguration or upstream provider error.' }
+          }
+        }
+      },
+      '/api/report-bug': {
+        post: {
+          summary: 'Submit a bug report or feature request.',
+          operationId: 'reportBug',
+          requestBody: {
+            required: true,
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  required: ['description'],
+                  properties: {
+                    email: { type: 'string', format: 'email' },
+                    description: { type: 'string', minLength: 1 },
+                    attachment: {
+                      type: 'object',
+                      properties: {
+                        name: { type: 'string' },
+                        content: { type: 'string' }
+                      },
+                      additionalProperties: false
+                    }
+                  },
+                  additionalProperties: false
+                }
+              }
+            }
+          },
+          responses: {
+            '200': { description: 'Report accepted.' },
+            '400': { description: 'Missing or invalid description.' },
+            '500': { description: 'Server misconfiguration or upstream provider error.' }
+          }
+        }
+      },
+      '/.well-known/status': {
+        get: {
+          summary: 'Return discovery endpoint status.',
+          operationId: 'getDiscoveryStatus',
+          responses: {
+            '200': { description: 'Discovery endpoint is available.' }
+          }
+        }
+      }
+    }
+  }
+
+  return new Response(JSON.stringify(openapi, null, 2), {
+    headers: {
+      'Content-Type': 'application/vnd.oai.openapi+json; charset=utf-8'
+    }
+  })
+}

--- a/src/app/.well-known/openid-configuration/route.ts
+++ b/src/app/.well-known/openid-configuration/route.ts
@@ -1,0 +1,1 @@
+export { GET } from '../oauth-authorization-server/route'

--- a/src/app/.well-known/status/route.ts
+++ b/src/app/.well-known/status/route.ts
@@ -1,0 +1,9 @@
+import { AppConfig } from '@/config'
+
+export function GET() {
+  return Response.json({
+    status: 'ok',
+    service: 'thorchain-swap',
+    url: AppConfig.baseUrl
+  })
+}

--- a/src/app/agent-auth/authorize/route.ts
+++ b/src/app/agent-auth/authorize/route.ts
@@ -1,0 +1,9 @@
+export function GET() {
+  return Response.json(
+    {
+      error: 'agent_auth_not_enabled',
+      error_description: 'Public self-service agent authorization is not currently enabled.'
+    },
+    { status: 501 }
+  )
+}

--- a/src/app/agent-auth/token/route.ts
+++ b/src/app/agent-auth/token/route.ts
@@ -1,0 +1,11 @@
+export function POST() {
+  return Response.json(
+    {
+      error: 'agent_auth_not_enabled',
+      error_description: 'Public self-service agent token issuance is not currently enabled.'
+    },
+    { status: 501 }
+  )
+}
+
+export const GET = POST

--- a/src/app/auth.md/route.ts
+++ b/src/app/auth.md/route.ts
@@ -1,0 +1,9 @@
+import { authMarkdown } from '@/lib/agent-discovery'
+
+export function GET() {
+  return new Response(authMarkdown, {
+    headers: {
+      'Content-Type': 'text/markdown; charset=utf-8'
+    }
+  })
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,6 +7,7 @@ import { ThemeProvider } from 'next-themes'
 import { NextIntlClientProvider } from 'next-intl'
 import { getLocale, getMessages } from 'next-intl/server'
 import { Toaster } from '@/components/ui/sonner'
+import { WebMcpTools } from '@/components/webmcp-tools'
 import { ReactQueryProvider } from '@/components/react-query/react-query-provider'
 import { WalletStoreHydration } from '@/components/wallet-store-hydration'
 import { AppConfig } from '@/config'
@@ -106,6 +107,7 @@ export default async function RootLayout({ children }: Readonly<{ children: Reac
         />
       )}
       <body className={`${crit.variable} ${notoRunic.variable} bg-body font-sans antialiased`}>
+        <WebMcpTools />
         <WalletStoreHydration />
         <ReactQueryProvider>
           <NextIntlClientProvider locale={locale} messages={messages}>

--- a/src/components/webmcp-tools.tsx
+++ b/src/components/webmcp-tools.tsx
@@ -1,0 +1,105 @@
+'use client'
+
+import { useEffect } from 'react'
+
+type WebMcpTool = {
+  name: string
+  description: string
+  inputSchema: Record<string, unknown>
+  execute: (input?: unknown) => Promise<unknown> | unknown
+}
+
+type ModelContext = {
+  registerTool?: (tool: WebMcpTool, options?: { signal?: AbortSignal }) => void | (() => void)
+}
+
+declare global {
+  interface Navigator {
+    modelContext?: ModelContext
+  }
+}
+
+const publicRoutes: Record<string, string> = {
+  swap: '/',
+  pool: 'https://pool.thorchain.org/',
+  bond: 'https://bond.thorchain.org/',
+  memo: 'https://memo.thorchain.org/',
+  tcy: 'https://tcy.thorchain.org/',
+  thorname: 'https://thorname.thorchain.org/'
+}
+
+function readRoute(input: unknown) {
+  if (!input || typeof input !== 'object' || !('route' in input)) return 'swap'
+  const route = (input as { route?: unknown }).route
+  return typeof route === 'string' && route in publicRoutes ? route : 'swap'
+}
+
+export function WebMcpTools() {
+  useEffect(() => {
+    const modelContext = navigator.modelContext
+    if (!modelContext?.registerTool) return
+
+    const controller = new AbortController()
+    const unregisters: Array<() => void> = []
+
+    const tools: WebMcpTool[] = [
+      {
+        name: 'get-thorchain-swap-page',
+        description: 'Return public metadata for the current THORChain Swap page.',
+        inputSchema: {
+          type: 'object',
+          additionalProperties: false,
+          properties: {}
+        },
+        execute: () => ({
+          title: document.title,
+          url: window.location.href,
+          origin: window.location.origin,
+          discovery: {
+            robots: `${window.location.origin}/robots.txt`,
+            sitemap: `${window.location.origin}/sitemap.xml`,
+            apiCatalog: `${window.location.origin}/.well-known/api-catalog`,
+            agentSkills: `${window.location.origin}/.well-known/agent-skills/index.json`
+          }
+        })
+      },
+      {
+        name: 'open-thorchain-swap-route',
+        description: 'Navigate to a stable public THORChain Swap route.',
+        inputSchema: {
+          type: 'object',
+          additionalProperties: false,
+          properties: {
+            route: {
+              type: 'string',
+              enum: Object.keys(publicRoutes),
+              description: 'Public route to open.'
+            }
+          }
+        },
+        execute: (input) => {
+          const route = readRoute(input)
+          const target = publicRoutes[route]
+          window.location.assign(target)
+          return { route, url: target }
+        }
+      }
+    ]
+
+    for (const tool of tools) {
+      try {
+        const unregister = modelContext.registerTool(tool, { signal: controller.signal })
+        if (typeof unregister === 'function') unregisters.push(unregister)
+      } catch (error) {
+        console.warn('[webmcp] Failed to register tool', tool.name, error)
+      }
+    }
+
+    return () => {
+      controller.abort()
+      for (const unregister of unregisters) unregister()
+    }
+  }, [])
+
+  return null
+}

--- a/src/lib/agent-discovery.ts
+++ b/src/lib/agent-discovery.ts
@@ -1,0 +1,66 @@
+import { createHash } from 'node:crypto'
+
+export const agentSkillMarkdown = `# THORChain Swap Agent Skill
+
+Use this skill when an agent needs to understand or navigate the public THORChain Swap interface.
+
+## What This Site Does
+
+THORChain Swap is a public web interface for native cross-chain swaps powered by THORChain and Maya Protocol providers.
+
+## Safe Public Actions
+
+- Read public discovery documents.
+- Open the swap interface.
+- Open the pool, bond, memo, TCY, and THORName public interfaces.
+- Submit feedback only through the documented public API.
+
+## Safety Rules
+
+- Do not request, store, or infer private keys or seed phrases.
+- Do not execute swaps for a user.
+- Do not connect wallets without explicit user action in the browser.
+- Treat quotes, balances, and transaction state as time-sensitive.
+- Confirm destination addresses before any user submits a transaction.
+
+## Discovery URLs
+
+- https://swap.thorchain.org/robots.txt
+- https://swap.thorchain.org/sitemap.xml
+- https://swap.thorchain.org/.well-known/api-catalog
+- https://swap.thorchain.org/.well-known/openapi.json
+- https://swap.thorchain.org/auth.md
+`
+
+export const authMarkdown = `# auth.md
+
+THORChain Swap publishes public discovery metadata for agents.
+
+## Audience
+
+This document is for agents and developers inspecting the public THORChain Swap web interface and its public support APIs.
+
+## Current Authentication Model
+
+The public web interface does not require account authentication for browsing.
+Wallet connection and transaction signing are performed by user-controlled wallets in the browser.
+
+The public support APIs documented in the API catalog are unauthenticated at the HTTP layer and may enforce server-side abuse controls.
+There is no public self-service OAuth credential issuance for agents at this time.
+
+## Discovery Metadata
+
+- OAuth authorization server metadata: https://swap.thorchain.org/.well-known/oauth-authorization-server
+- OAuth protected resource metadata: https://swap.thorchain.org/.well-known/oauth-protected-resource
+- OpenID configuration: https://swap.thorchain.org/.well-known/openid-configuration
+- API catalog: https://swap.thorchain.org/.well-known/api-catalog
+
+## Agent Registration
+
+Self-service agent registration is not currently enabled.
+Teams that need authenticated integration access should coordinate with the THORChain Swap maintainers.
+`
+
+export function sha256Digest(value: string) {
+  return `sha256:${createHash('sha256').update(value, 'utf8').digest('hex')}`
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,11 +1,47 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { PRIMARY_HOST, SUBDOMAIN_ROUTES } from '@/config'
+import { AppConfig, PRIMARY_HOST, SUBDOMAIN_ROUTES } from '@/config'
+
+const homeMarkdown = `# THORChain Swap
+
+THORChain Swap is the public swap interface for THORChain powered cross-chain swaps.
+
+## Public Pages
+
+- [Swap interface](${AppConfig.baseUrl}/)
+- [Pool interface](https://pool.thorchain.org/)
+- [Bond interface](https://bond.thorchain.org/)
+- [Memo interface](https://memo.thorchain.org/)
+- [TCY interface](https://tcy.thorchain.org/)
+- [THORName interface](https://thorname.thorchain.org/)
+
+## Machine-Readable Discovery
+
+- [robots.txt](${AppConfig.baseUrl}/robots.txt)
+- [sitemap.xml](${AppConfig.baseUrl}/sitemap.xml)
+- [API catalog](${AppConfig.baseUrl}/.well-known/api-catalog)
+- [OpenAPI description](${AppConfig.baseUrl}/.well-known/openapi.json)
+- [Agent skills index](${AppConfig.baseUrl}/.well-known/agent-skills/index.json)
+- [Auth.md](${AppConfig.baseUrl}/auth.md)
+`
+
+function acceptsMarkdown(req: NextRequest) {
+  return req.headers.get('accept')?.toLowerCase().includes('text/markdown') ?? false
+}
 
 export function proxy(req: NextRequest) {
   const host = (req.headers.get('host') || '').split(':')[0]
   if (!host.endsWith('.thorchain.org')) return NextResponse.next()
 
   const { pathname, search } = req.nextUrl
+
+  if (host === PRIMARY_HOST && pathname === '/' && acceptsMarkdown(req)) {
+    return new NextResponse(homeMarkdown, {
+      headers: {
+        'Content-Type': 'text/markdown; charset=utf-8',
+        'x-markdown-tokens': String(Math.ceil(homeMarkdown.split(/\s+/).length * 1.35))
+      }
+    })
+  }
 
   for (const route of SUBDOMAIN_ROUTES) {
     if (pathname === route.path || pathname.startsWith(route.path + '/')) {


### PR DESCRIPTION
## What changed

Adds machine-readable agent discovery surfaces for swap.thorchain.org without changing the visible swap UI, wallet flows, quote logic, or transaction execution.

- Adds robots.txt with wildcard, AI crawler, Content Signal, and sitemap directives.
- Adds sitemap.xml for the canonical swap homepage.
- Adds homepage Link headers for API catalog, OpenAPI, auth.md, and agent skills discovery.
- Adds Markdown negotiation for the homepage when agents request Accept: text/markdown.
- Adds .well-known discovery endpoints for API catalog, OpenAPI, OAuth/OIDC metadata, OAuth protected resource metadata, auth.md, MCP server card, A2A agent card, agent skills, JWKS, and status.
- Adds hidden WebMCP browser tool registration that renders no UI.
- Adds DNS-AID owner notes because DNS records must be configured outside this repo.

## Why

The isitagentready scan reported missing or invalid discovery surfaces, including robots.txt rules, sitemap.xml, Link headers, Markdown for Agents, AI crawler rules, Content Signals, API catalog, OAuth metadata, auth.md, MCP server card, A2A agent card, agent skills, and WebMCP.

## Impact

No expected visual changes. These changes add machine-readable files, well-known endpoints, headers, and a non-rendering client component. Owners should review the OAuth/MCP/A2A metadata because those are discovery claims rather than full production auth or MCP infrastructure.

## Validation

- `git diff --check HEAD~1 HEAD` passed.
- Static checks confirmed required scanner strings for robots.txt, sitemap.xml, discovery headers, Markdown negotiation, WebMCP, and A2A card.
- Full `npm ci` / build was not run: upstream package-lock.json is out of sync with package.json, and dependency install hit low local disk space.

## Remaining outside repo

DNS-AID still requires DNS/SVCB or HTTPS records and DNSSEC configuration outside this application repo.
